### PR TITLE
Cached skip() generator values

### DIFF
--- a/cisco_live_downloader.py
+++ b/cisco_live_downloader.py
@@ -152,10 +152,11 @@ def skip():
     for f in files_to_download():
         if f in check_current_files():
             yield f
-
-pool = ThreadPool(pool_workers)
+            
+skippable = list(skip())
+pool      = ThreadPool(pool_workers)
 results   = pool.map(get_links, links)
-results = [res for res in results if res['name'] + '.mp4' not in skip()]
+results   = [res for res in results if res['name'] + '.mp4' not in skippable]
 
 print('''About to download {} resources. This may take a long time depending on your bandwidth...'''.format(len(results)))
 


### PR DESCRIPTION
the skip() generator was being called repeatedly in a loop where it was being re-evaluated per iteration, but does not have any dependencies on the values within the loop. Storing the results of the generator before using it in a loop saves hundreds of further unnecessary generator calls. This can be a potential bottleneck if several videos were to be downloaded.
