### PR TITLE
moved skip cache after finding the results

### DIFF
--- a/cisco_live_downloader.py
+++ b/cisco_live_downloader.py
@@ -153,9 +153,10 @@ def skip():
         if f in check_current_files():
             yield f
             
-skippable = list(skip())
+
 pool      = ThreadPool(pool_workers)
 results   = pool.map(get_links, links)
+skippable = list(skip())
 results   = [res for res in results if res['name'] + '.mp4' not in skippable]
 
 print('''About to download {} resources. This may take a long time depending on your bandwidth...'''.format(len(results)))


### PR DESCRIPTION
The previous change to cache the results was a breaking change, as the optimization was done in the wrong location. To store the results of skip() it needs to be done after the pool workers finish processing the get_links function,
